### PR TITLE
23w42a port, TNT template

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,10 +36,10 @@ repositories {
 }
 
 dependencies {
-	minecraft "com.mojang:minecraft:1.20.1"
-	mappings "net.fabricmc:yarn:1.20.1+build.2"
-	modApi "net.fabricmc:fabric-loader:0.14.21"
-	modApi "net.fabricmc.fabric-api:fabric-api:0.83.1+1.20.1"
+	minecraft "com.mojang:minecraft:23w42a"
+	mappings "net.fabricmc:yarn:23w42a+build.1"
+	modApi "net.fabricmc:fabric-loader:0.14.23"
+	modApi "net.fabricmc.fabric-api:fabric-api:0.90.3+1.20.3"
 
 	implementation "com.google.code.findbugs:jsr305:3.0.2"
 

--- a/src/main/java/io/github/cottonmc/templates/Templates.java
+++ b/src/main/java/io/github/cottonmc/templates/Templates.java
@@ -1,24 +1,7 @@
 package io.github.cottonmc.templates;
 
 import io.github.cottonmc.templates.api.TemplateInteractionUtil;
-import io.github.cottonmc.templates.block.TemplateBlock;
-import io.github.cottonmc.templates.block.TemplateButtonBlock;
-import io.github.cottonmc.templates.block.TemplateCandleBlock;
-import io.github.cottonmc.templates.block.TemplateCarpetBlock;
-import io.github.cottonmc.templates.block.TemplateDoorBlock;
-import io.github.cottonmc.templates.block.TemplateEntity;
-import io.github.cottonmc.templates.block.TemplateFenceBlock;
-import io.github.cottonmc.templates.block.TemplateFenceGateBlock;
-import io.github.cottonmc.templates.block.TemplateLeverBlock;
-import io.github.cottonmc.templates.block.TemplatePaneBlock;
-import io.github.cottonmc.templates.block.TemplatePostBlock;
-import io.github.cottonmc.templates.block.TemplatePressurePlateBlock;
-import io.github.cottonmc.templates.block.TemplateSlabBlock;
-import io.github.cottonmc.templates.block.TemplateSlopeBlock;
-import io.github.cottonmc.templates.block.TemplateStairsBlock;
-import io.github.cottonmc.templates.block.TemplateTrapdoorBlock;
-import io.github.cottonmc.templates.block.TemplateVerticalSlabBlock;
-import io.github.cottonmc.templates.block.TemplateWallBlock;
+import io.github.cottonmc.templates.block.*;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup;
 import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
@@ -53,7 +36,7 @@ public class Templates implements ModInitializer {
 	
 	//addon devs: *Don't* add your blocks to this collection, it's just for my registration convenience since Templates adds a lot of blocks...
 	@ApiStatus.Internal static final ArrayList<Block> INTERNAL_TEMPLATES = new ArrayList<>();
-	@ApiStatus.Internal static Block CUBE, STAIRS, SLAB, VERTICAL_SLAB, POST, FENCE, FENCE_GATE, DOOR, TRAPDOOR, IRON_DOOR, IRON_TRAPDOOR, PRESSURE_PLATE, BUTTON, LEVER, WALL, CARPET, PANE, CANDLE, SLOPE, TINY_SLOPE, COOL_RIVULET;
+	@ApiStatus.Internal static Block CUBE, STAIRS, SLAB, VERTICAL_SLAB, POST, FENCE, FENCE_GATE, DOOR, TRAPDOOR, IRON_DOOR, IRON_TRAPDOOR, PRESSURE_PLATE, BUTTON, LEVER, WALL, CARPET, PANE, CANDLE, SLOPE, TINY_SLOPE, TNT, COOL_RIVULET;
 	
 	//For addon devs: Please don't stuff more blocks into this BlockEntityType, and register your own.
 	//You can even re-register the same TemplateEntity class under your own ID if you like. (It's an extensible block entity.)
@@ -89,6 +72,7 @@ public class Templates implements ModInitializer {
 		CANDLE         = registerTemplate("candle"        , new TemplateCandleBlock(TemplateCandleBlock.configureSettings(cp(Blocks.CANDLE))));
 		SLOPE          = registerTemplate("slope"         , new TemplateSlopeBlock(TemplateInteractionUtil.makeSettings()));
 		TINY_SLOPE     = registerTemplate("tiny_slope"    , new TemplateSlopeBlock.Tiny(TemplateInteractionUtil.makeSettings()));
+		TNT            = registerTemplate("tnt"           , new TemplateTntBlock(cp(Blocks.TNT)));
 		
 		//The block entity is still called templates:slope; this is a bit of a legacy mistake.
 		TEMPLATE_BLOCK_ENTITY = Registry.register(Registries.BLOCK_ENTITY_TYPE, id("slope"),

--- a/src/main/java/io/github/cottonmc/templates/TemplatesClient.java
+++ b/src/main/java/io/github/cottonmc/templates/TemplatesClient.java
@@ -108,6 +108,7 @@ public class TemplatesClient implements ClientModInitializer {
 		api.assignItemModel(Templates.id("wall_inventory_special")        , Templates.WALL);
 		api.assignItemModel(Templates.id("slope_special")                 , Templates.SLOPE);
 		api.assignItemModel(Templates.id("tiny_slope_special")            , Templates.TINY_SLOPE);
+		api.assignItemModel(Templates.id("cube_special")                  , Templates.TNT);
 		
 		//TODO: i could stick some kind of entrypoint here for signalling other mods that it's ok to register now?
 		// Dont think it rly matters though, everything's all kept in nice hash maps

--- a/src/main/java/io/github/cottonmc/templates/block/TemplateButtonBlock.java
+++ b/src/main/java/io/github/cottonmc/templates/block/TemplateButtonBlock.java
@@ -27,11 +27,11 @@ import org.jetbrains.annotations.Nullable;
 
 public class TemplateButtonBlock extends ButtonBlock implements BlockEntityProvider {
 	public TemplateButtonBlock(Settings settings) {
-		this(settings, BlockSetType.OAK, 30, true);
+		this(settings, BlockSetType.OAK, 30);
 	}
 	
-	public TemplateButtonBlock(Settings settings, BlockSetType blockSetType, int i, boolean bl) {
-		super(settings, blockSetType, i, bl);
+	public TemplateButtonBlock(Settings settings, BlockSetType blockSetType, int i) {
+		super(blockSetType, i, settings);
 		setDefaultState(TemplateInteractionUtil.setDefaultStates(getDefaultState()));
 	}
 	

--- a/src/main/java/io/github/cottonmc/templates/block/TemplateDoorBlock.java
+++ b/src/main/java/io/github/cottonmc/templates/block/TemplateDoorBlock.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class TemplateDoorBlock extends DoorBlock implements BlockEntityProvider {
 	public TemplateDoorBlock(Settings settings, BlockSetType blockSetType) {
-		super(settings, blockSetType);
+		super(blockSetType, settings);
 		setDefaultState(TemplateInteractionUtil.setDefaultStates(getDefaultState()));
 	}
 	

--- a/src/main/java/io/github/cottonmc/templates/block/TemplatePressurePlateBlock.java
+++ b/src/main/java/io/github/cottonmc/templates/block/TemplatePressurePlateBlock.java
@@ -26,13 +26,13 @@ import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 
 public class TemplatePressurePlateBlock extends PressurePlateBlock implements BlockEntityProvider {
-	public TemplatePressurePlateBlock(ActivationRule activationRule, Settings settings, BlockSetType blockSetType) {
-		super(activationRule, settings, blockSetType);
+	public TemplatePressurePlateBlock(Settings settings, BlockSetType blockSetType) {
+		super(blockSetType, settings);
 		setDefaultState(TemplateInteractionUtil.setDefaultStates(getDefaultState()));
 	}
 	
 	public TemplatePressurePlateBlock(Settings settings) {
-		this(ActivationRule.EVERYTHING, settings, BlockSetType.OAK);
+		this(settings, BlockSetType.OAK);
 	}
 	
 	@Override

--- a/src/main/java/io/github/cottonmc/templates/block/TemplateTntBlock.java
+++ b/src/main/java/io/github/cottonmc/templates/block/TemplateTntBlock.java
@@ -3,13 +3,7 @@ package io.github.cottonmc.templates.block;
 import com.google.common.base.MoreObjects;
 import io.github.cottonmc.templates.Templates;
 import io.github.cottonmc.templates.api.TemplateInteractionUtil;
-import io.github.cottonmc.templates.api.TemplateInteractionUtilExt;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockEntityProvider;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.FenceGateBlock;
-import net.minecraft.block.ShapeContext;
-import net.minecraft.block.WoodType;
+import net.minecraft.block.*;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -26,73 +20,64 @@ import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 
-public class TemplateFenceGateBlock extends FenceGateBlock implements BlockEntityProvider, TemplateInteractionUtilExt {
-	public TemplateFenceGateBlock(Settings settings, WoodType woodType) {
-		super(woodType, settings);
+public class TemplateTntBlock extends TntBlock implements BlockEntityProvider {
+	public TemplateTntBlock(Settings settings) {
+		super(settings);
 		setDefaultState(TemplateInteractionUtil.setDefaultStates(getDefaultState()));
 	}
-	
-	public TemplateFenceGateBlock(Settings settings) {
-		this(settings, WoodType.OAK);
-	}
-	
+
 	@Nullable
 	@Override
 	public BlockEntity createBlockEntity(BlockPos pos, BlockState state) {
 		return Templates.TEMPLATE_BLOCK_ENTITY.instantiate(pos, state);
 	}
-	
+
+	@Override
+	protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
+		super.appendProperties(TemplateInteractionUtil.appendProperties(builder));
+	}
+
 	@Nullable
 	@Override
 	public BlockState getPlacementState(ItemPlacementContext ctx) {
 		return TemplateInteractionUtil.modifyPlacementState(super.getPlacementState(ctx), ctx);
 	}
-	
-	@Override
-	protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
-		super.appendProperties(TemplateInteractionUtil.appendProperties(builder));
-	}
-	
+
 	@Override
 	public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
 		ActionResult r = TemplateInteractionUtil.onUse(state, world, pos, player, hand, hit);
 		if(!r.isAccepted()) r = super.onUse(state, world, pos, player, hand, hit);
 		return r;
 	}
-	
+
 	@Override
 	public void onStateReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean moved) {
 		TemplateInteractionUtil.onStateReplaced(state, world, pos, newState, moved);
 		super.onStateReplaced(state, world, pos, newState, moved);
 	}
-	
+
 	@Override
 	public void onPlaced(World world, BlockPos pos, BlockState state, @Nullable LivingEntity placer, ItemStack stack) {
 		TemplateInteractionUtil.onPlaced(world, pos, state, placer, stack);
 	}
-	
+
 	@Override
 	public VoxelShape getCollisionShape(BlockState state, BlockView view, BlockPos pos, ShapeContext ctx) {
 		return MoreObjects.firstNonNull(TemplateInteractionUtil.getCollisionShape(state, view, pos, ctx), super.getCollisionShape(state, view, pos, ctx));
 	}
-	
+
 	@Override
 	public boolean emitsRedstonePower(BlockState state) {
 		return TemplateInteractionUtil.emitsRedstonePower(state);
 	}
-	
+
 	@Override
 	public int getWeakRedstonePower(BlockState state, BlockView view, BlockPos pos, Direction dir) {
 		return TemplateInteractionUtil.getWeakRedstonePower(state, view, pos, dir);
 	}
-	
+
 	@Override
 	public int getStrongRedstonePower(BlockState state, BlockView view, BlockPos pos, Direction dir) {
 		return TemplateInteractionUtil.getStrongRedstonePower(state, view, pos, dir);
-	}
-	
-	@Override
-	public boolean templatesPlayerCanAddRedstoneEmission(BlockState state, BlockView view, BlockPos pos) {
-		return false;
 	}
 }

--- a/src/main/java/io/github/cottonmc/templates/block/TemplateTrapdoorBlock.java
+++ b/src/main/java/io/github/cottonmc/templates/block/TemplateTrapdoorBlock.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class TemplateTrapdoorBlock extends TrapdoorBlock implements BlockEntityProvider, TemplateInteractionUtilExt {
 	public TemplateTrapdoorBlock(Settings settings, BlockSetType blah) {
-		super(settings, blah);
+		super(blah, settings);
 		setDefaultState(TemplateInteractionUtil.setDefaultStates(getDefaultState()));
 	}
 	

--- a/src/main/java/io/github/cottonmc/templates/mixin/MixinTntBlock.java
+++ b/src/main/java/io/github/cottonmc/templates/mixin/MixinTntBlock.java
@@ -1,0 +1,28 @@
+package io.github.cottonmc.templates.mixin;
+
+import io.github.cottonmc.templates.api.ThemeableBlockEntity;
+import net.minecraft.block.TntBlock;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.TntEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(TntBlock.class)
+public class MixinTntBlock {
+	@Inject(
+			method = "primeTnt(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/entity/LivingEntity;)V",
+			at = @At(value = "INVOKE", target = "net/minecraft/world/World.spawnEntity(Lnet/minecraft/entity/Entity;)Z"),
+			locals = LocalCapture.CAPTURE_FAILEXCEPTION
+	)
+	private static void handleTemplateTnt(World world, BlockPos pos, @Nullable LivingEntity living, CallbackInfo info, TntEntity tnt) {
+		if (world.getBlockEntity(pos) instanceof ThemeableBlockEntity be) {
+			tnt.method_54455(be.getThemeState());
+		}
+	}
+}

--- a/src/main/resources/assets/templates/blockstates/tnt.json
+++ b/src/main/resources/assets/templates/blockstates/tnt.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "templates:cube_special"
+        }
+    }
+}

--- a/src/main/resources/assets/templates/lang/en_us.json
+++ b/src/main/resources/assets/templates/lang/en_us.json
@@ -19,6 +19,7 @@
 	"block.templates.slab": "Slab Template",
 	"block.templates.stairs": "Stairs Template",
 	"block.templates.trapdoor": "Trapdoor Template",
+	"block.templates.tnt": "TNT Template",
 	"block.templates.vertical_slab": "Vertical Slab Template",
 	"block.templates.wall": "Wall Template",
 	

--- a/src/main/resources/data/templates/advancements/recipes/decorations/templates.json
+++ b/src/main/resources/data/templates/advancements/recipes/decorations/templates.json
@@ -21,7 +21,8 @@
 			"templates:vertical_slab",
 			"templates:wall",
 			"templates:slope",
-			"templates:tiny_slope"
+			"templates:tiny_slope",
+			"templates:tnt"
 		]
 	},
 	"criteria": {

--- a/src/main/resources/data/templates/loot_tables/blocks/tnt.json
+++ b/src/main/resources/data/templates/loot_tables/blocks/tnt.json
@@ -1,0 +1,19 @@
+{
+    "type": "minecraft:block",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "templates:tnt"
+                }
+            ],
+            "conditions": [
+                {
+                    "condition": "minecraft:survives_explosion"
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/data/templates/recipes/tnt.json
+++ b/src/main/resources/data/templates/recipes/tnt.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "~I~",
+        "I~I",
+        "~I~"
+    ],
+    "key": {
+        "I": {
+            "item": "minecraft:bamboo"
+        },
+        "~": {
+            "item": "minecraft:gunpowder"
+        }
+    },
+    "result": {
+        "item": "templates:tnt",
+        "count": 1
+    },
+    "group": "templates"
+}

--- a/src/main/resources/templates.mixins.json
+++ b/src/main/resources/templates.mixins.json
@@ -1,20 +1,21 @@
 {
-	"required": true,
-	"package": "io.github.cottonmc.templates.mixin",
-	"compatibilityLevel": "JAVA_17",
-	"mixins": [
-		"MinecraftAccessor",
-		"WallBlockAccessor",
-		"particles.MixinEntity",
-		"particles.MixinLivingEntity"
-	],
-	"client": [
-		"particles.AccessorParticle",
-		"particles.AccessorSpriteBillboardParticle",
-		"particles.MixinBlockDustParticle"
-	],
-	"injectors": {
-		"defaultRequire": 1
-	},
-	"refmap": "templates.refmap.json"
+    "required": true,
+    "package": "io.github.cottonmc.templates.mixin",
+    "compatibilityLevel": "JAVA_17",
+    "mixins": [
+        "MinecraftAccessor",
+        "MixinTntBlock",
+        "WallBlockAccessor",
+        "particles.MixinEntity",
+        "particles.MixinLivingEntity"
+    ],
+    "client": [
+        "particles.AccessorParticle",
+        "particles.AccessorSpriteBillboardParticle",
+        "particles.MixinBlockDustParticle"
+    ],
+    "injectors": {
+        "defaultRequire": 1
+    },
+    "refmap": "templates.refmap.json"
 }


### PR DESCRIPTION
This ports Templates to 23w42a - mostly involving changes to argument order, but also pressure plate activation rules and button durations are determined by `BlockSetType` now(?) - as well as adding the TNT template, taking advantage of the fact that TNT can now visually display as any blockstate.

Making a TNT template emit redstone by any means, whether through the properties of the mimicked blockstate or through adding redstone dust, will cause it to ignite as soon as either it or any of its neighbors receive a block update. Why would you do this? The answer remains to be seen.

This is *extremely* low-effort and purely for the sake of shitposting, but then again that's not exactly out of place in this mod lmao. Thank you for resuscitating it and making it better than I could have ever imagined - consider this me returning the favor.